### PR TITLE
exposing a percy-tests helper to make it easy to test all routes

### DIFF
--- a/addon/percy-tests.js
+++ b/addon/percy-tests.js
@@ -1,0 +1,35 @@
+import { visit } from '@ember/test-helpers';
+import { get } from '@ember/object';
+import { percySnapshot } from 'ember-percy';
+
+export default function (test) {
+  test('visual regressions with Percy', async function(assert) {
+    assert.expect(0);
+    await visit('/release');
+
+    let store = this.owner.lookup('service:store');
+    let pages = store.peekAll('page');
+
+    await pages.reduce(async (prev, section) => {
+      await prev;
+
+      return section.get('pages').reduce(async (prev, page) => {
+        await prev;
+
+        let url = get(page, 'url');
+
+        await visit(`/release/${url}`);
+
+        let name = `/${page.url}/index.html`;
+
+        if (page.url.endsWith('index')) {
+          name = `/${page.url}.html`;
+        } else if (page.url.endsWith('index/')) {
+          name = '/index.html';
+        }
+
+        await percySnapshot(name);
+      }, Promise.resolve());
+    }, Promise.resolve());
+  });
+}


### PR DESCRIPTION
Currently we have custom code in https://github.com/ember-learn/guides-source/blob/master/tests/acceptance/visual-regression-test.js that walks through each route in the latest version of the guides and takes a Percy snapshot. This PR adds a helper that can be used as followed: 

```
import { module, test } from 'qunit';
import { setupApplicationTest } from 'ember-qunit';
import percyTests from 'guidemaker/percy-tests';

module('Acceptance | visual regressions', function(hooks) {
  setupApplicationTest(hooks);

  percyTests(test);
});
```

This way we can share the functionality between users guidemaker without needing to duplicate code 👍 