### PR TITLE
remove unsupported node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "qunit-dom": "^0.8.0"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "8.* || >= 10.*"
   },
   "fastbootDependencies": [
     "algoliasearch"


### PR DESCRIPTION
@mansona highlighted that prember does not support node < 8 in the following post:
https://github.com/ember-learn/guides-app/pull/402#issuecomment-477497125
This project has prember as a dependency, so it makes sense to remove node 6 from the engines tag and only support 8+