### PR TITLE
implementing netlifyRedirects()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3385,12 +3385,26 @@
         "yaml-front-matter": "^3.4.0"
       },
       "dependencies": {
+        "commander": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-1.0.0.tgz",
+          "integrity": "sha1-XmqI5wcP9ZCINurRkWlUjDD5C80="
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
+          }
+        },
+        "yaml-front-matter": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/yaml-front-matter/-/yaml-front-matter-3.4.1.tgz",
+          "integrity": "sha1-5S6E/qaYO5N1XpsVZNupibAGtaU=",
+          "requires": {
+            "commander": "1.0.0",
+            "js-yaml": "^3.5.2"
           }
         }
       }
@@ -17054,12 +17068,12 @@
       }
     },
     "yaml-front-matter": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/yaml-front-matter/-/yaml-front-matter-3.4.1.tgz",
-      "integrity": "sha1-5S6E/qaYO5N1XpsVZNupibAGtaU=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yaml-front-matter/-/yaml-front-matter-4.0.0.tgz",
+      "integrity": "sha1-EcN4xU6sMGGoLLr2k6abTkxE9IQ=",
       "requires": {
         "commander": "1.0.0",
-        "js-yaml": "^3.5.2"
+        "js-yaml": "^3.10.0"
       },
       "dependencies": {
         "commander": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Guidemaker Core Engine",
   "keywords": [
     "ember-addon",
+    "ember-cli-netlify-plugin",
     "prember-plugin"
   ],
   "repository": "https://github.com/empress/guidemaker",
@@ -38,7 +39,8 @@
     "recast": "^0.15.3",
     "resolve": "^1.8.1",
     "showdown-section-groups": "^0.3.0",
-    "walk-sync": "^0.3.2"
+    "walk-sync": "^0.3.2",
+    "yaml-front-matter": "^4.0.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",


### PR DESCRIPTION
This adds the existing redirect functionality to netlify redirects (if the consuming app has ember-cli-netlify installed 👍) 

This is safe to merge but it will not do anything until https://github.com/shipshapecode/ember-cli-netlify/pull/8 is merged 
