### PR TITLE
bugfix - cannot read length of undefined

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ jobs:
         - npm run lint:js
         - npm run test:node
         - npm run test:ember
+        - npx ember build -prod
 
     - stage: "Additional Tests"
       name: "Floating Dependencies"

--- a/app/routes/version/show.js
+++ b/app/routes/version/show.js
@@ -25,6 +25,14 @@ function normalisePath(path, pages) {
 
   let currentPage = pages.find(page => page.id === parts[0]);
 
+
+  // if the current page is not found then we might be in a redirect file for a
+  // section that has been removed from the ToC. In this case we're not going to
+  // be able to normalise the path so just return it without change.
+  if(!currentPage) {
+    return path;
+  }
+
   if (
     parts.length === 1
     && currentPage.pages

--- a/node-tests/netlify-redirects.js
+++ b/node-tests/netlify-redirects.js
@@ -23,6 +23,7 @@ describe('netlifyRedirects() function in index', function () {
       '/release/getting-started/redirect /release/getting-started/editing',
       '/v1.2.0/getting-started/redirect /release/getting-started/editing',
       '/v1.0.0/getting-started/redirect /v1.0.0/getting-started/editing',
+      '/v1.1.0/old-content /v1.1.0/getting-started'
     ]);
   })
 });

--- a/tests/dummy/guides/v1.0.0/old-content/index.md
+++ b/tests/dummy/guides/v1.0.0/old-content/index.md
@@ -1,1 +1,1 @@
-Here is a page with content that was removed in later versions.
+Here is a page with content that will be removed in later versions.

--- a/tests/dummy/guides/v1.1.0/old-content/index.md
+++ b/tests/dummy/guides/v1.1.0/old-content/index.md
@@ -1,0 +1,3 @@
+---
+redirect: getting-started
+---


### PR DESCRIPTION
If an index file is a redirect, skip it.

This was causing an error in Ember Guides builds for files like controllers/index.md. It blocks upgrading to the latest version of guidemaker. This would be a candidate for a patch release.