### PR TITLE
resolve default serializer deprecation

### DIFF
--- a/addon/serializers/application.js
+++ b/addon/serializers/application.js
@@ -1,0 +1,6 @@
+import JSONAPISerializer from '@ember-data/serializer/json-api';
+
+// This serializer must exist because of https://deprecations.emberjs.com/ember-data/v3.x/#toc_ember-data:default-serializers
+
+export default class ApplicationSerializer extends JSONAPISerializer {
+}

--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -1,0 +1,1 @@
+export { default } from 'guidemaker/serializers/application';

--- a/tests/unit/serializers/application-test.js
+++ b/tests/unit/serializers/application-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Serializer | application', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let serializer = store.serializerFor('application');
+
+    assert.ok(serializer);
+  });
+});


### PR DESCRIPTION
See https://deprecations.emberjs.com/ember-data/v3.x/#toc_ember-data:default-serializers

Basically, every app that uses Ember Data needs to have an explicit serializer.

This was the deprecation:

```
            WARN: DEPRECATION: store.serializerFor("content") resolved the "-json-api" serializer via the deprecated `adapter.defaultSerializer` property.

            	Previously, if no application or type-specific serializer was specified, the store would attempt to lookup a serializer via the `defaultSerializer` property on the type's adapter. This behavior is deprecated in favor of explicitly defining a type-specific serializer or application serializer [deprecation id: ember-data:default-serializer] See https://deprecations.emberjs.com/ember-data/v3.x#toc_ember-data:default-serializers for more details.
                    at logDeprecationStackTrace (http://localhost:7357/assets/vendor.js:37467:21)
                    at HANDLERS.<computed> (http://localhost:7357/assets/vendor.js:37564:9)
                    at raiseOnDeprecation (http://localhost:7357/assets/vendor.js:37494:9)
                    at HANDLERS.<computed> (http://localhost:7357/assets/vendor.js:37564:9)
                    at invoke (http://localhost:7357/assets/vendor.js:37576:9)
                    at Object.deprecate (http://localhost:7357/assets/vendor.js:37532:28)
                    at Store.serializerFor (http://localhost:7357/assets/vendor.js:96248:39)
                    at http://localhost:7357/assets/vendor.js:93313:30
                    at invokeCallback (http://localhost:7357/assets/vendor.js:61639:17)
```