### PR TITLE
add sourceBranch as a guidemaker config param

### DIFF
--- a/addon/services/guidemaker.js
+++ b/addon/services/guidemaker.js
@@ -15,5 +15,6 @@ export default Service.extend({
   social: configParam('social'),
   copyright: configParam('copyright'),
   sourceRepo: configParam('sourceRepo'),
+  sourceBranch: configParam('sourceBranch'),
   collapseToc: configParam('collapseToc'),
 });


### PR DESCRIPTION
This is to elevate the fix in https://github.com/ember-learn/guidemaker-ember-template/pull/77 to a "first-class" guidemaker feature.

Essentially this will allow templates to stop assuming that the branch they need to edit is `master` 👍 