### PR TITLE
Refactor guidemaker service to accept any config field

### DIFF
--- a/addon/services/guidemaker.js
+++ b/addon/services/guidemaker.js
@@ -1,21 +1,13 @@
-/* eslint-disable prettier/prettier, ember/no-classic-classes */
 import Service from '@ember/service';
-import { computed, get } from '@ember/object';
 
 import config from 'ember-get-config';
 
-function configParam(param) {
-  return computed(function() {
-    return get(config, `guidemaker.${param}`);
-  })
-}
+export default class GuidemakerService extends Service {
+  constructor() {
+    super(...arguments);
 
-export default Service.extend({
-  title: configParam('title'),
-  logo: configParam('logo'),
-  social: configParam('social'),
-  copyright: configParam('copyright'),
-  sourceRepo: configParam('sourceRepo'),
-  sourceBranch: configParam('sourceBranch'),
-  collapseToc: configParam('collapseToc'),
-});
+    for (const [key, value] of Object.entries(config.guidemaker)) {
+      this[key] = value;
+    }
+  }
+}

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -25,8 +25,9 @@ module.exports = function (environment) {
     },
 
     guidemaker: {
+      anyConfig: 'Define any config specifics to your Guidemaker Docs',
       description: 'Guides - Built with Guidemaker',
-      title: 'Guidemaker Docs'
+      title: 'Guidemaker Docs',
     }
   };
 

--- a/tests/unit/services/guidemaker-test.js
+++ b/tests/unit/services/guidemaker-test.js
@@ -1,0 +1,15 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | service | guidemaker', function (hooks) {
+  setupTest(hooks);
+
+  test('can provide the guidemaker config', function (assert) {
+    const service = this.owner.lookup('service:guidemaker');
+    assert.strictEqual(service.title, 'Guidemaker Docs');
+    assert.strictEqual(
+      service.anyConfig,
+      'Define any config specifics to your Guidemaker Docs'
+    );
+  });
+});


### PR DESCRIPTION
Closes #89 

This PR refactors `guidemaker` service so any field can be read from the guidemaker environment config:
```
// your-guidemaker-app/config/environment.js

guidemaker: {
  anyConfig: 'Define any config specifics to your Guidemaker Docs',
}
```