### PR TITLE
Removed `included()` method, which only added `ember-prism` options. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -287,29 +287,4 @@ You should move it into the 'guides' folder.
       'ember-collapsible-panel': config['ember-collapsible-panel'] || {}
     }
   },
-
-  included(app) {
-    this._super.included.apply(this, arguments)
-
-    if(!app.options['ember-prism']) {
-      app.options['ember-prism'] = {
-        theme: 'okaidia',
-
-        components: [
-          'apacheconf',
-          'bash',
-          'css',
-          'handlebars',
-          'http',
-          'javascript',
-          'json',
-          'markup-templating',
-          'ruby',
-          'scss'
-        ],
-
-        plugins: ['line-numbers', 'normalize-whitespace']
-      }
-    }
-  },
 };


### PR DESCRIPTION
Now we count on `ember-showdown-prism` to do that, and having a set of options applied in here prevents them from being applied in there. This branch passes tests and runs locally, so I don't think I broke anything.

Full disclosure: This project, built on Ember 3.28, has no ember-try cases for Ember 4, and all the release, beta, canary cases for Ember 5 fail because of references to `@ember/debug`, which no longer exists, in `ember-data` 3.28, which this project uses. I temporarily added cases for Ember 4.8 and 4.12 and they both passed ember-try.  None of this behavior differed in this branch from the behavior in main, so it is all an existing condition.
