### PR TITLE
Fix `ember-data:deprecate-array-like` deprecation

### DIFF
--- a/addon/services/page.js
+++ b/addon/services/page.js
@@ -102,7 +102,7 @@ export default class PageService extends Service {
   @computed('pages')
   get pageTree() {
     let { pages } = this;
-    return buildPageTreeNode(pages.toArray ? pages.toArray() : pages);
+    return buildPageTreeNode(pages.slice ? pages.slice() : pages);
   }
 
   @computed('content.id', 'pageTree')


### PR DESCRIPTION
Use `Array.prototype.slice` instead of `RecordArray.prototype.toArray`

Needed by https://github.com/ember-learn/guides-source/pull/1986